### PR TITLE
build sequence file supports workingFolder option for spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Each release is a different release. It may be necessary to perform deployments 
     },
     {
       "type": "datapack",
+      "workingFolder":"vlocitydatapacks",
       "manifestFile": "manifest/sfi-package.yaml"
     },
     {

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each release is a different release. It may be necessary to perform deployments 
     },
     {
       "type": "datapack",
-      "workingFolder":"vlocitydatapacks",
+      "workingFolder": "vlocitydatapacks",
       "manifestFile": "manifest/sfi-package.yaml"
     },
     {
@@ -119,8 +119,10 @@ Some considerations regarding this configuration file:
   - If the `testLevel` is not specified, the script will deploy using `RunLocalTests`;
   - Normally on your pipeline sandboxes you will deploy using `enableTracking` as a `false` - which is the default value. If you want to use source tracking you can use this value as `true`;
   - `outputFormat` is an optional parameter and the only acceptable value is json. If informed, the `--json` will be append in the `sf project deploy start` command. Please, be aware that if the deployment is big, this output format could impact the maxBuffer size of the command output and fail the process.
+- For builds with the `type` parameter set to `datapack`:
+  - The `manifestFile` field is required;
+  - `workingFolder` is optional but is useful in some situations that the VBT will fail to generate and deploy LWC components due to not recognizing other metadata types that are present in your sfdx project package directories - in these situations VBT will throw the error `UnexpectedFileFound: Unexpected file found in package directory: PATH_TO_METADATA`. Therefore setting the `workingFolder` parameter to some other directory will execute the `vlocity packDeploy` command in another subfolder therefore making it a completly new sfdx project.
 - For other types of deployments:
-  - If `type` is `datapack`, the `manifestFile` field is required;
   - If `type` is `anonymousApex`, the `apexScript` field is required;
   - If `type` is `command`, the `command` field is required - this could be any shell command that you want to execute. There is also the possibility to instruct the plugin to include the connected target-org in any specific format that you want using for that the two optional parameters `includeTargetOrg` (default to `false`) and `targetOrgFormat` (default to `--target-org`).
 

--- a/src/modules/commands.ts
+++ b/src/modules/commands.ts
@@ -147,6 +147,6 @@ export default class Commands {
       throw new Error(`Build type not supported ${build.type}`);
     }
 
-    return BuildsUtils.execCommand(buildCommand, buildCommandArgs);
+    return BuildsUtils.execCommand(buildCommand, buildCommandArgs, build.workingFolder);
   }
 }

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -11,6 +11,7 @@ export type AuthParameters = {
 
 export type Build = {
   type: string;
+  workingFolder?: string;
   manifestFile?: string;
   preDestructiveChanges?: string;
   postDestructiveChanges?: string;


### PR DESCRIPTION
#178 

build sequence file supports workingFolder option for spawn.
You can now define workingFolderin the build file so the command will be executed inside the designated folder. It implies that the manifests file should consider the working folder for relative paths.

Sample:

```
{

    "builds": [
        {
            "type": "datapack",
            "workingFolder": "vlocitydatapacks",
            "manifestFile": "../manifest/baseline-omniscript.yaml"
        }
    ]
} 
```

