### PR TITLE
ci: modernize release workflows to current action versions

### DIFF
--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -7,12 +7,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
+        uses: TriPSs/conventional-changelog-action@v6
         # overriding some of the basic behaviors to just get the changelog
         with:
           git-user-name: Tiago Nascimento
@@ -20,15 +21,13 @@ jobs:
           # always do the release, even if there are no semantic commits
           skip-on-empty: false
           tag-prefix: ''
-      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
-        id: packageVersion
-        with:
-          path: 'package.json'
-          prop_path: 'version'
       - name: Create Github Release
-        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.packageVersion.outputs.prop }}
-          release_name: ${{ steps.packageVersion.outputs.prop }}
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          make_latest: true

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -7,28 +7,36 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: tag that needs to publish
+        description: github tag that needs to publish
         type: string
         required: true
+      npmTag:
+        description: npm dist-tag to publish under
+        type: string
+        required: false
+        default: latest
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      NPM_TAG: ${{ inputs.npmTag || 'latest' }}
     steps:
-      - name: Release
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.githubTag }}
-      - uses: actions/setup-node@v3
+          ref: ${{ env.GITHUB_TAG }}
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.nodeVersion }}
+          node-version: lts/*
           cache: yarn
       - run: yarn install --network-timeout 600000
       - run: yarn build
-      - run: npm install --global @salesforce/plugin-release-management@3.7.3
+      - run: npm install --global @salesforce/plugin-release-management@5
       - run: |
           sf-release npm:package:release \
-            --githubtag ${{ github.event.release.tag_name || inputs.tag || 'latest' }} \
-            --npmtag ${{ inputs.tag || 'latest' }} \
+            --githubtag "$GITHUB_TAG" \
+            --npmtag "$NPM_TAG" \
             --no-install
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release-cycle workflows were emitting the deprecation warnings you've been seeing and contained two latent bugs that bit during the 2.0.0 release. This brings them up to current, maintained action versions without changing the release model.

## Why

- **Node 20 deprecation warnings** on every run — `actions/checkout@v3` and `actions/setup-node@v3` are forced onto the deprecated Node 20 runtime.
- **`onRelease.yml` had `node-version: ${{ inputs.nodeVersion }}`** — an input that doesn't exist (the input is `tag`), so the Node version was empty.
- **The npm dist-tag was derived from the GitHub tag**, so a manual re-run with `tag=2.0.0` produced `npm publish --tag 2.0.0` → `npm error Tag name must not be a valid SemVer range: 2.0.0`. (This is exactly what blocked the manual 2.0.0 re-publish.)
- **`manualRelease.yml` used `actions/create-release@v1`** — archived/unmaintained since 2021.

## Changes

**`onRelease.yml` (publish)**
- `actions/checkout@v3 → v4`, `actions/setup-node@v3 → v4`
- Fix `node-version` → `lts/*` (with yarn cache)
- Add explicit `npmTag` input (default `latest`); stop deriving the dist-tag from the github tag
- Pass interpolated values via `env:` vars (avoids workflow-injection surface in `run:` steps)
- `@salesforce/plugin-release-management@3.7.3 → @5`

**`manualRelease.yml`**
- `actions/checkout@v3 → v4` (`fetch-depth: 0` for changelog history)
- `TriPSs/conventional-changelog-action → v6`
- Replace archived `actions/create-release@v1` with maintained `softprops/action-gh-release@v2`; reuse the action's computed tag + generated changelog body; skip release creation when there are no semantic commits

## Note (separate from this PR)

The wrong 1.7.3→2.0.0 bump earlier happened because the `refactor:` merge commit described its breaking change in prose only. The action computes the bump from conventional-commit semantics, so a major bump requires a `BREAKING CHANGE:` footer or `!` in the type. That's a commit-hygiene fix, not a workflow fix — flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)